### PR TITLE
fix: restrict snakemake to v7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "pandas>=1.5",
         "pandas-stubs>=1.5",
         "drmaa>=0.7.9",
-        "snakemake>=7.24",
+        "snakemake>=7.24, <=7.32",
         "xlrd>=2.0",
         "pyyaml>=6.0",
         "types-PyYAML>=6.0",


### PR DESCRIPTION
Snakemake v8 has major breaking changes, which breaks the juno-library install. This PR restricts snakemake to v7.32