### PR TITLE
Enlist for clustering

### DIFF
--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -418,7 +418,6 @@ class Pipeline:
         self.input_dir_is_juno_mapping_output = self.__check_input_dir(
             ["mapped_reads/duprem", "variants", "reference/reference.fasta"]
         )
-        print(self.input_dir_is_juno_mapping_output)
         self.input_dir_is_juno_variant_typing_output = self.__check_input_dir(
             ["*/consensus", "audit_trail"]
         )

--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -403,7 +403,7 @@ class Pipeline:
         }
         # check if self.input_type is a str or a tuple
         if isinstance(self.input_type, str):
-            self.input_type = tuple(conversion_dict[self.input_type]) 
+            self.input_type = tuple(conversion_dict[self.input_type])
 
     def __build_sample_dict(self) -> None:
         """Look for samples in input_dir and set self.sample_dict accordingly.

--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -392,10 +392,10 @@ class Pipeline:
 
         """
         conversion_dict = {
-            "fastq": ("fastq"),
-            "fasta": ("fasta"),
-            "vcf": ("vcf"),
-            "bam": ("bam"),
+            "fastq": ("fastq",),
+            "fasta": ("fasta",),
+            "vcf": ("vcf",),
+            "bam": ("bam",),
             "both": ("fastq", "fasta"),
             "fastq_and_fasta": ("fastq", "fasta"),
             "fastq_and_vcf": ("fastq", "vcf"),

--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -366,7 +366,7 @@ class Pipeline:
         ----------
         expected_files_dirs : List[str]
             List of patterns that are expected to be found in the input directory.
-        
+
         Returns
         -------
         bool
@@ -421,7 +421,9 @@ class Pipeline:
         self.input_dir_is_juno_variant_typing_output = self.__check_input_dir(
             ["*/consensus", "audit_trail"]
         )
-        self.input_dir_is_juno_cgmlst_output = self.__check_input_dir(["cgmlst/*", "audit_trail"])
+        self.input_dir_is_juno_cgmlst_output = self.__check_input_dir(
+            ["cgmlst/*", "audit_trail"]
+        )
         if self.input_dir_is_juno_assembly_output:
             self.__enlist_fastq_samples(self.input_dir.joinpath("clean_fastq"))
             self.__enlist_samples_custom_extension(
@@ -430,31 +432,47 @@ class Pipeline:
                 key="assembly",
             )
         elif self.input_dir_is_juno_mapping_output:
-            self.__enlist_samples_custom_extension(self.input_dir.joinpath("mapped_reads", "duprem"), extension=".bam", key="bam")
-            self.__enlist_samples_custom_extension(self.input_dir.joinpath("variants"), extension=".vcf", key="vcf")
+            self.__enlist_samples_custom_extension(
+                self.input_dir.joinpath("mapped_reads", "duprem"),
+                extension=".bam",
+                key="bam",
+            )
+            self.__enlist_samples_custom_extension(
+                self.input_dir.joinpath("variants"), extension=".vcf", key="vcf"
+            )
         elif self.input_dir_is_juno_variant_typing_output:
             consensus_paths = list(self.input_dir.glob("*/consensus"))
             assert len(consensus_paths) == 1, error_formatter(
                 f"""Expected to find exactly one consensus directory in the input directory ({self.input_dir}).\n
                 Found {len(list(consensus_paths))}."""
             )
-            self.__enlist_samples_custom_extension(consensus_paths[0], extension=".fasta", key="assembly")
+            self.__enlist_samples_custom_extension(
+                consensus_paths[0], extension=".fasta", key="assembly"
+            )
         elif self.input_dir_is_juno_cgmlst_output:
-            raise NotImplementedError("Using juno-cgmlst output is not yet implemented.")
+            raise NotImplementedError(
+                "Using juno-cgmlst output is not yet implemented."
+            )
             # TODO: juno-cgmlst should output a TSV file with the cgmlst results per sample, which should be enlisted here. Can be multiple schemes per sample.
             # Could be in the format: {sample: {cgmlst_scheme1: cgmlst_file1, cgmlst_scheme2: cgmlst_file2}}
             # self.__enlist_samples_custom_extension(self.input_dir.joinpath("cgmlst"), extension=".tsv", key="cgmlst")
         else:
-            self.__parse_input_type() # TODO: remove this line when self.input_type is a list in all pipelines
+            self.__parse_input_type()  # TODO: remove this line when self.input_type is a list in all pipelines
             if "fastq" in self.input_type:
                 self.__enlist_fastq_samples(self.input_dir)
             if "fasta" in self.input_type:
-                self.__enlist_samples_custom_extension(self.input_dir, extension=".fasta", key="assembly")
+                self.__enlist_samples_custom_extension(
+                    self.input_dir, extension=".fasta", key="assembly"
+                )
             if "vcf" in self.input_type:
-                self.__enlist_samples_custom_extension(self.input_dir, extension=".vcf", key="vcf")
+                self.__enlist_samples_custom_extension(
+                    self.input_dir, extension=".vcf", key="vcf"
+                )
                 self.__enlist_reference(self.input_dir)
             if "bam" in self.input_type:
-                self.__enlist_samples_custom_extension(self.input_dir, extension=".bam", key="bam")
+                self.__enlist_samples_custom_extension(
+                    self.input_dir, extension=".bam", key="bam"
+                )
 
     def __enlist_fastq_samples(self, dir: Path) -> None:
         """Function to enlist the fastq files found in the input directory.
@@ -557,7 +575,9 @@ class Pipeline:
     #                 sample = self.sample_dict.setdefault(sample_name, {})
     #                 sample["bam"] = str(file_.resolve())
 
-    def __enlist_samples_custom_extension(self, dir: Path, extension: str, key: str) -> None:
+    def __enlist_samples_custom_extension(
+        self, dir: Path, extension: str, key: str
+    ) -> None:
         """Function to enlist files found in the input directory based on a custom extension.
         Adds or updates self.sample_dict with the form:
 

--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -47,7 +47,7 @@ class Pipeline:
     pipeline_name: str
     pipeline_version: str
 
-    input_type: Union[str, List[str]] = "both"
+    input_type: Union[str, Tuple[str]] = "both"
     fasta_dir: Optional[Path] = None
     fastq_dir: Optional[Path] = None
     vcf_dir: Optional[Path] = None
@@ -96,7 +96,7 @@ class Pipeline:
     def __post_init__(
         self,
     ) -> None:
-        # TODO: remove this line when self.input_type is a list in all pipelines
+        # TODO: remove this line when self.input_type is a tuple in all pipelines
         if isinstance(self.input_type, str):
             assert self.input_type in [
                 "fastq",
@@ -108,10 +108,10 @@ class Pipeline:
                 "fastq_and_vcf",
                 "bam_and_vcf",
             ], "if input_type is a str, the value can only be 'fastq', 'fasta', 'vcf', 'bam', 'both'/'fastq_and_fasta', 'fastq_and_vcf' or 'bam_and_vcf'"
-        elif isinstance(self.input_type, list):
+        elif isinstance(self.input_type, tuple):
             assert all(
                 [x in ["fastq", "fasta", "vcf", "bam"] for x in self.input_type]
-            ), "if input_type is a list, the values can only be 'fastq', 'fasta', 'vcf' or 'bam'"
+            ), "if input_type is a tuple, the values can only be 'fastq', 'fasta', 'vcf' or 'bam'"
 
         self.snakemake_config["sample_sheet"] = str(self.sample_sheet)
         self.add_argument = self.parser.add_argument
@@ -386,22 +386,22 @@ class Pipeline:
 
     def __parse_input_type(self) -> None:
         """
-        Convert self.input_type to a list if it is a string.
+        Convert self.input_type to a tuple if it is a string.
 
-        This function can be deprecated when all pipelines have switched to using a list for self.input_type.
+        This function can be deprecated when all pipelines have switched to using a tuple for self.input_type.
 
         """
         conversion_dict = {
-            "fastq": ["fastq"],
-            "fasta": ["fasta"],
-            "vcf": ["vcf"],
-            "bam": ["bam"],
-            "both": ["fastq", "fasta"],
-            "fastq_and_fasta": ["fastq", "fasta"],
-            "fastq_and_vcf": ["fastq", "vcf"],
-            "bam_and_vcf": ["bam", "vcf"],
+            "fastq": ("fastq"),
+            "fasta": ("fasta"),
+            "vcf": ("vcf"),
+            "bam": ("bam"),
+            "both": ("fastq", "fasta"),
+            "fastq_and_fasta": ("fastq", "fasta"),
+            "fastq_and_vcf": ("fastq", "vcf"),
+            "bam_and_vcf": ("bam", "vcf"),
         }
-        # check if self.input_type is a str or a list
+        # check if self.input_type is a str or a tuple
         if isinstance(self.input_type, str):
             self.input_type = conversion_dict[self.input_type]
 

--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -47,7 +47,7 @@ class Pipeline:
     pipeline_name: str
     pipeline_version: str
 
-    input_type: Union[str, Tuple[str]] = "both"
+    input_type: Union[str, Tuple[str, ...]] = "both"
     fasta_dir: Optional[Path] = None
     fastq_dir: Optional[Path] = None
     vcf_dir: Optional[Path] = None
@@ -403,7 +403,7 @@ class Pipeline:
         }
         # check if self.input_type is a str or a tuple
         if isinstance(self.input_type, str):
-            self.input_type = conversion_dict[self.input_type]
+            self.input_type = tuple(conversion_dict[self.input_type]) 
 
     def __build_sample_dict(self) -> None:
         """Look for samples in input_dir and set self.sample_dict accordingly.

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -457,7 +457,11 @@ class TestPipelineStartup(unittest.TestCase):
                     Path("fake_dir_wsamples").joinpath("sample1_R2.fastq.gz").resolve()
                 ),
                 "vcf": str(Path("fake_dir_wsamples").joinpath("sample1.vcf").resolve()),
-                "reference": str(Path("fake_dir_wsamples").joinpath("reference", "reference.fasta").resolve()),
+                "reference": str(
+                    Path("fake_dir_wsamples")
+                    .joinpath("reference", "reference.fasta")
+                    .resolve()
+                ),
             },
             "sample2": {
                 "R1": str(
@@ -469,7 +473,11 @@ class TestPipelineStartup(unittest.TestCase):
                     .resolve()
                 ),
                 "vcf": str(Path("fake_dir_wsamples").joinpath("sample2.vcf").resolve()),
-                "reference": str(Path("fake_dir_wsamples").joinpath("reference", "reference.fasta").resolve()),
+                "reference": str(
+                    Path("fake_dir_wsamples")
+                    .joinpath("reference", "reference.fasta")
+                    .resolve()
+                ),
             },
         }
         pipeline = Pipeline(
@@ -485,30 +493,49 @@ class TestPipelineStartup(unittest.TestCase):
 
         input_dir = Path("fake_dir_wsamples_juno_cgmlst").resolve()
         input_dir.mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("cgmlst", "escherichia", "per_sample").mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("cgmlst", "stec", "per_sample").mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("cgmlst", "shigella", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "escherichia", "per_sample").mkdir(
+            exist_ok=True, parents=True
+        )
+        input_dir.joinpath("cgmlst", "stec", "per_sample").mkdir(
+            exist_ok=True, parents=True
+        )
+        input_dir.joinpath("cgmlst", "shigella", "per_sample").mkdir(
+            exist_ok=True, parents=True
+        )
         input_dir.joinpath("audit_trail").mkdir(exist_ok=True, parents=True)
 
-        make_non_empty_file(input_dir.joinpath("cgmlst", "escherichia", "per_sample", "sample1.tsv"))
-        make_non_empty_file(input_dir.joinpath("cgmlst", "stec", "per_sample", "sample1.tsv"))
-        make_non_empty_file(input_dir.joinpath("cgmlst", "shigella", "per_sample", "sample1.tsv"))
+        make_non_empty_file(
+            input_dir.joinpath("cgmlst", "escherichia", "per_sample", "sample1.tsv")
+        )
+        make_non_empty_file(
+            input_dir.joinpath("cgmlst", "stec", "per_sample", "sample1.tsv")
+        )
+        make_non_empty_file(
+            input_dir.joinpath("cgmlst", "shigella", "per_sample", "sample1.tsv")
+        )
 
         expected_output = {
             "sample1": {
                 "cgmlst_escherichia": str(
-                    Path("fake_dir_wsamples_juno_cgmlst").joinpath("cgmlst","escherichia","per_sample","sample1.tsv").resolve()
+                    Path("fake_dir_wsamples_juno_cgmlst")
+                    .joinpath("cgmlst", "escherichia", "per_sample", "sample1.tsv")
+                    .resolve()
                 ),
                 "cgmlst_stec": str(
-                    Path("fake_dir_wsamples_juno_cgmlst").joinpath("cgmlst","stec","per_sample","sample1.tsv").resolve()
+                    Path("fake_dir_wsamples_juno_cgmlst")
+                    .joinpath("cgmlst", "stec", "per_sample", "sample1.tsv")
+                    .resolve()
                 ),
                 "cgmlst_shigella": str(
-                    Path("fake_dir_wsamples_juno_cgmlst").joinpath("cgmlst","shigella","per_sample","sample1.tsv").resolve()
+                    Path("fake_dir_wsamples_juno_cgmlst")
+                    .joinpath("cgmlst", "shigella", "per_sample", "sample1.tsv")
+                    .resolve()
                 ),
             },
         }
         pipeline = Pipeline(
-            **default_args, argv=["-i", "fake_dir_wsamples_juno_cgmlst"],
+            **default_args,
+            argv=["-i", "fake_dir_wsamples_juno_cgmlst"],
         )
         with self.assertRaises(NotImplementedError):
             pipeline.setup()
@@ -544,7 +571,9 @@ class TestPipelineStartup(unittest.TestCase):
             },
         }
         pipeline = Pipeline(
-            **default_args, argv=["-i", "fake_dir_wsamples"], input_type=["fastq", "fasta"]
+            **default_args,
+            argv=["-i", "fake_dir_wsamples"],
+            input_type=["fastq", "fasta"],
         )
         pipeline.setup()
         pipeline.get_metadata_from_csv_file()
@@ -560,11 +589,15 @@ class TestPipelineStartup(unittest.TestCase):
         input_dir = Path("fake_dir_juno_assembly_output").resolve()
         input_dir.mkdir(exist_ok=True, parents=True)
         input_dir.joinpath("clean_fastq").mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("de_novo_assembly_filtered").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("de_novo_assembly_filtered").mkdir(
+            exist_ok=True, parents=True
+        )
 
         make_non_empty_file(input_dir.joinpath("clean_fastq", "sample_A_R1.fastq.gz"))
         make_non_empty_file(input_dir.joinpath("clean_fastq", "sample_A_R2.fastq.gz"))
-        make_non_empty_file(input_dir.joinpath("de_novo_assembly_filtered", "sample_A.fasta"))
+        make_non_empty_file(
+            input_dir.joinpath("de_novo_assembly_filtered", "sample_A.fasta")
+        )
 
         pipeline = Pipeline(
             **default_args, argv=["-i", str(input_dir)], input_type="both"
@@ -578,7 +611,6 @@ class TestPipelineStartup(unittest.TestCase):
         pipeline_input_type_list.setup()
         self.assertTrue(pipeline_input_type_list.input_dir_is_juno_assembly_output)
 
-
     def test_recognize_juno_mapping_output(self) -> None:
         """
         Testing that the pipeline recognizes the output of the Juno mapping pipeline
@@ -590,7 +622,9 @@ class TestPipelineStartup(unittest.TestCase):
         input_dir.joinpath("variants").mkdir(exist_ok=True, parents=True)
         input_dir.joinpath("reference").mkdir(exist_ok=True, parents=True)
 
-        make_non_empty_file(input_dir.joinpath("mapped_reads", "duprem", "sample_A.bam"))
+        make_non_empty_file(
+            input_dir.joinpath("mapped_reads", "duprem", "sample_A.bam")
+        )
         make_non_empty_file(input_dir.joinpath("variants", "sample_A.vcf"))
         make_non_empty_file(input_dir.joinpath("reference", "reference.fasta"))
 
@@ -599,7 +633,7 @@ class TestPipelineStartup(unittest.TestCase):
         )
         pipeline.setup()
         self.assertTrue(pipeline.input_dir_is_juno_mapping_output)
-    
+
     def test_recognize_juno_variant_typing_output(self) -> None:
         """
         Testing that the pipeline recognizes the output of the Juno variant typing pipeline
@@ -609,9 +643,11 @@ class TestPipelineStartup(unittest.TestCase):
         input_dir.mkdir(exist_ok=True, parents=True)
         input_dir.joinpath("mtb_typing", "consensus").mkdir(exist_ok=True, parents=True)
         input_dir.joinpath("audit_trail").mkdir(exist_ok=True, parents=True)
-        
-        make_non_empty_file(input_dir.joinpath("mtb_typing", "consensus", "sample_A.fasta"))
-        
+
+        make_non_empty_file(
+            input_dir.joinpath("mtb_typing", "consensus", "sample_A.fasta")
+        )
+
         pipeline = Pipeline(
             **default_args, argv=["-i", str(input_dir)], input_type=["fasta"]
         )
@@ -625,17 +661,30 @@ class TestPipelineStartup(unittest.TestCase):
 
         input_dir = Path("fake_dir_juno_cgmlst_output").resolve()
         input_dir.mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("cgmlst", "escherichia", "per_sample").mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("cgmlst", "shigella", "per_sample").mkdir(exist_ok=True, parents=True)
-        input_dir.joinpath("cgmlst", "stec", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "escherichia", "per_sample").mkdir(
+            exist_ok=True, parents=True
+        )
+        input_dir.joinpath("cgmlst", "shigella", "per_sample").mkdir(
+            exist_ok=True, parents=True
+        )
+        input_dir.joinpath("cgmlst", "stec", "per_sample").mkdir(
+            exist_ok=True, parents=True
+        )
         input_dir.joinpath("audit_trail").mkdir(exist_ok=True, parents=True)
-        
-        make_non_empty_file(input_dir.joinpath("cgmlst", "escherichia", "per_sample", "sample_A.tsv"))
-        make_non_empty_file(input_dir.joinpath("cgmlst", "stec", "per_sample", "sample_A.tsv"))
-        make_non_empty_file(input_dir.joinpath("cgmlst", "shigella", "per_sample", "sample_A.tsv"))
-        
+
+        make_non_empty_file(
+            input_dir.joinpath("cgmlst", "escherichia", "per_sample", "sample_A.tsv")
+        )
+        make_non_empty_file(
+            input_dir.joinpath("cgmlst", "stec", "per_sample", "sample_A.tsv")
+        )
+        make_non_empty_file(
+            input_dir.joinpath("cgmlst", "shigella", "per_sample", "sample_A.tsv")
+        )
+
         pipeline = Pipeline(
-            **default_args, argv=["-i", str(input_dir)],
+            **default_args,
+            argv=["-i", str(input_dir)],
         )
         with self.assertRaises(NotImplementedError):
             pipeline.setup()

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -639,7 +639,7 @@ class TestPipelineStartup(unittest.TestCase):
         )
         with self.assertRaises(NotImplementedError):
             pipeline.setup()
-            self.assertTrue(pipeline.input_dir_is_juno_variant_typing_output)
+            self.assertTrue(pipeline.input_dir_is_juno_cgmlst_output)
 
     def test_files_smaller_than_minlen(self) -> None:
         """Testing the pipeline startup fails if you set a min_num_lines

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -164,6 +164,7 @@ class TestPipelineStartup(unittest.TestCase):
         fake_dirs = [
             "fake_dir_empty",
             "fake_dir_wsamples",
+            "fake_dir_wsamples/reference",
             "fake_dir_wsamples_exclusion",
             "exclusion_file",
             "fake_dir_incomplete",
@@ -173,6 +174,11 @@ class TestPipelineStartup(unittest.TestCase):
             "fake_dir_juno/identify_species",
             "fake_1_in_fastqname",
             "fake_multiple_library_samples",
+            "fake_dir_juno_assembly_output",
+            "fake_dir_juno_mapping_output",
+            "fake_dir_juno_variant_typing_output",
+            "fake_dir_juno_cgmlst_output",
+            "fake_dir_wsamples_juno_cgmlst",
         ]
 
         fake_files = [
@@ -184,6 +190,7 @@ class TestPipelineStartup(unittest.TestCase):
             "fake_dir_wsamples/sample2.fasta",
             "fake_dir_wsamples/sample1.vcf",
             "fake_dir_wsamples/sample2.vcf",
+            "fake_dir_wsamples/reference/reference.fasta",
             "fake_dir_wsamples_exclusion/sample1_R1.fastq",
             "fake_dir_wsamples_exclusion/sample1_R2.fastq.gz",
             "fake_dir_wsamples_exclusion/sample2_R1_filt.fq",
@@ -208,7 +215,7 @@ class TestPipelineStartup(unittest.TestCase):
         ]
 
         for folder in fake_dirs:
-            Path(folder).mkdir(exist_ok=True)
+            Path(folder).mkdir(exist_ok=True, parents=True)
         for file_ in fake_files:
             make_non_empty_file(file_)
         bracken_dir = Path("fake_dir_juno").joinpath("identify_species")
@@ -229,6 +236,7 @@ class TestPipelineStartup(unittest.TestCase):
         fake_dirs = [
             "fake_dir_empty",
             "fake_dir_wsamples",
+            "fake_dir_wsamples_library_names",
             "fake_dir_wsamples_exclusion",
             "exclusion_file",
             "fake_dir_incomplete",
@@ -238,6 +246,11 @@ class TestPipelineStartup(unittest.TestCase):
             "fake_dir_juno/identify_species",
             "fake_1_in_fastqname",
             "fake_multiple_library_samples",
+            "fake_dir_juno_assembly_output",
+            "fake_dir_juno_mapping_output",
+            "fake_dir_juno_variant_typing_output",
+            "fake_dir_juno_cgmlst_output",
+            "fake_dir_wsamples_juno_cgmlst",
         ]
 
         for folder in fake_dirs:
@@ -338,7 +351,13 @@ class TestPipelineStartup(unittest.TestCase):
     def test_correctdir_fastq_with_library_in_filename(self) -> None:
         """Testing the pipeline startup accepts fastq and fastq.gz files"""
 
-        input_dir = Path("fake_dir_wsamples").resolve()
+        input_dir = Path("fake_dir_wsamples_library_names").resolve()
+        input_dir.mkdir(exist_ok=True, parents=True)
+
+        make_non_empty_file(input_dir.joinpath("sample1_R1.fastq"))
+        make_non_empty_file(input_dir.joinpath("sample1_R2.fastq.gz"))
+        make_non_empty_file(input_dir.joinpath("sample2_R1_filt.fq"))
+        make_non_empty_file(input_dir.joinpath("sample2_R2_filt.fq.gz"))
         make_non_empty_file(input_dir.joinpath("sample3_S182_L555_R1_001.fastq.gz"))
         make_non_empty_file(input_dir.joinpath("sample3_S182_L555_R2_001.fastq.gz"))
         make_non_empty_file(input_dir.joinpath("sample4_S183_L001_R1_001.fastq.gz"))
@@ -438,6 +457,7 @@ class TestPipelineStartup(unittest.TestCase):
                     Path("fake_dir_wsamples").joinpath("sample1_R2.fastq.gz").resolve()
                 ),
                 "vcf": str(Path("fake_dir_wsamples").joinpath("sample1.vcf").resolve()),
+                "reference": str(Path("fake_dir_wsamples").joinpath("reference", "reference.fasta").resolve()),
             },
             "sample2": {
                 "R1": str(
@@ -449,6 +469,7 @@ class TestPipelineStartup(unittest.TestCase):
                     .resolve()
                 ),
                 "vcf": str(Path("fake_dir_wsamples").joinpath("sample2.vcf").resolve()),
+                "reference": str(Path("fake_dir_wsamples").joinpath("reference", "reference.fasta").resolve()),
             },
         }
         pipeline = Pipeline(
@@ -458,6 +479,167 @@ class TestPipelineStartup(unittest.TestCase):
         pipeline.get_metadata_from_csv_file()
         self.assertDictEqual(pipeline.sample_dict, expected_output)
         self.assertIsNone(pipeline.juno_metadata)
+
+    def test_correctdir_cgmlst(self) -> None:
+        """Testing the pipeline startup accepts juno-cgmlst"""
+
+        input_dir = Path("fake_dir_wsamples_juno_cgmlst").resolve()
+        input_dir.mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "escherichia", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "stec", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "shigella", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("audit_trail").mkdir(exist_ok=True, parents=True)
+
+        make_non_empty_file(input_dir.joinpath("cgmlst", "escherichia", "per_sample", "sample1.tsv"))
+        make_non_empty_file(input_dir.joinpath("cgmlst", "stec", "per_sample", "sample1.tsv"))
+        make_non_empty_file(input_dir.joinpath("cgmlst", "shigella", "per_sample", "sample1.tsv"))
+
+        expected_output = {
+            "sample1": {
+                "cgmlst_escherichia": str(
+                    Path("fake_dir_wsamples_juno_cgmlst").joinpath("cgmlst","escherichia","per_sample","sample1.tsv").resolve()
+                ),
+                "cgmlst_stec": str(
+                    Path("fake_dir_wsamples_juno_cgmlst").joinpath("cgmlst","stec","per_sample","sample1.tsv").resolve()
+                ),
+                "cgmlst_shigella": str(
+                    Path("fake_dir_wsamples_juno_cgmlst").joinpath("cgmlst","shigella","per_sample","sample1.tsv").resolve()
+                ),
+            },
+        }
+        pipeline = Pipeline(
+            **default_args, argv=["-i", "fake_dir_wsamples_juno_cgmlst"],
+        )
+        with self.assertRaises(NotImplementedError):
+            pipeline.setup()
+            self.assertDictEqual(pipeline.sample_dict, expected_output)
+
+    def test_correctdir_with_input_type_as_list(self) -> None:
+        """Testing the pipeline startup accepts both types"""
+
+        expected_output = {
+            "sample1": {
+                "R1": str(
+                    Path("fake_dir_wsamples").joinpath("sample1_R1.fastq").resolve()
+                ),
+                "R2": str(
+                    Path("fake_dir_wsamples").joinpath("sample1_R2.fastq.gz").resolve()
+                ),
+                "assembly": str(
+                    Path("fake_dir_wsamples").joinpath("sample1.fasta").resolve()
+                ),
+            },
+            "sample2": {
+                "R1": str(
+                    Path("fake_dir_wsamples").joinpath("sample2_R1_filt.fq").resolve()
+                ),
+                "R2": str(
+                    Path("fake_dir_wsamples")
+                    .joinpath("sample2_R2_filt.fq.gz")
+                    .resolve()
+                ),
+                "assembly": str(
+                    Path("fake_dir_wsamples").joinpath("sample2.fasta").resolve()
+                ),
+            },
+        }
+        pipeline = Pipeline(
+            **default_args, argv=["-i", "fake_dir_wsamples"], input_type=["fastq", "fasta"]
+        )
+        pipeline.setup()
+        pipeline.get_metadata_from_csv_file()
+        print(pipeline.sample_dict)
+        self.assertDictEqual(pipeline.sample_dict, expected_output)
+        self.assertIsNone(pipeline.juno_metadata)
+
+    def test_recognize_juno_assembly_output(self) -> None:
+        """
+        Testing that the pipeline recognizes the output of the Juno assembly pipeline
+        """
+
+        input_dir = Path("fake_dir_juno_assembly_output").resolve()
+        input_dir.mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("clean_fastq").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("de_novo_assembly_filtered").mkdir(exist_ok=True, parents=True)
+
+        make_non_empty_file(input_dir.joinpath("clean_fastq", "sample_A_R1.fastq.gz"))
+        make_non_empty_file(input_dir.joinpath("clean_fastq", "sample_A_R2.fastq.gz"))
+        make_non_empty_file(input_dir.joinpath("de_novo_assembly_filtered", "sample_A.fasta"))
+
+        pipeline = Pipeline(
+            **default_args, argv=["-i", str(input_dir)], input_type="both"
+        )
+        pipeline.setup()
+        self.assertTrue(pipeline.input_dir_is_juno_assembly_output)
+
+        pipeline_input_type_list = Pipeline(
+            **default_args, argv=["-i", str(input_dir)], input_type=["fastq", "fasta"]
+        )
+        pipeline_input_type_list.setup()
+        self.assertTrue(pipeline_input_type_list.input_dir_is_juno_assembly_output)
+
+
+    def test_recognize_juno_mapping_output(self) -> None:
+        """
+        Testing that the pipeline recognizes the output of the Juno mapping pipeline
+        """
+
+        input_dir = Path("fake_dir_juno_mapping_output").resolve()
+        input_dir.mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("mapped_reads", "duprem").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("variants").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("reference").mkdir(exist_ok=True, parents=True)
+
+        make_non_empty_file(input_dir.joinpath("mapped_reads", "duprem", "sample_A.bam"))
+        make_non_empty_file(input_dir.joinpath("variants", "sample_A.vcf"))
+        make_non_empty_file(input_dir.joinpath("reference", "reference.fasta"))
+
+        pipeline = Pipeline(
+            **default_args, argv=["-i", str(input_dir)], input_type=["bam", "vcf"]
+        )
+        pipeline.setup()
+        self.assertTrue(pipeline.input_dir_is_juno_mapping_output)
+    
+    def test_recognize_juno_variant_typing_output(self) -> None:
+        """
+        Testing that the pipeline recognizes the output of the Juno variant typing pipeline
+        """
+
+        input_dir = Path("fake_dir_juno_variant_typing_output").resolve()
+        input_dir.mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("mtb_typing", "consensus").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("audit_trail").mkdir(exist_ok=True, parents=True)
+        
+        make_non_empty_file(input_dir.joinpath("mtb_typing", "consensus", "sample_A.fasta"))
+        
+        pipeline = Pipeline(
+            **default_args, argv=["-i", str(input_dir)], input_type=["fasta"]
+        )
+        pipeline.setup()
+        self.assertTrue(pipeline.input_dir_is_juno_variant_typing_output)
+
+    def test_recognize_juno_cgmlst_output(self) -> None:
+        """
+        Testing that the pipeline recognizes the output of the Juno cgmlst pipeline
+        """
+
+        input_dir = Path("fake_dir_juno_cgmlst_output").resolve()
+        input_dir.mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "escherichia", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "shigella", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("cgmlst", "stec", "per_sample").mkdir(exist_ok=True, parents=True)
+        input_dir.joinpath("audit_trail").mkdir(exist_ok=True, parents=True)
+        
+        make_non_empty_file(input_dir.joinpath("cgmlst", "escherichia", "per_sample", "sample_A.tsv"))
+        make_non_empty_file(input_dir.joinpath("cgmlst", "stec", "per_sample", "sample_A.tsv"))
+        make_non_empty_file(input_dir.joinpath("cgmlst", "shigella", "per_sample", "sample_A.tsv"))
+        
+        pipeline = Pipeline(
+            **default_args, argv=["-i", str(input_dir)],
+        )
+        with self.assertRaises(NotImplementedError):
+            pipeline.setup()
+            self.assertTrue(pipeline.input_dir_is_juno_variant_typing_output)
 
     def test_files_smaller_than_minlen(self) -> None:
         """Testing the pipeline startup fails if you set a min_num_lines

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -541,7 +541,7 @@ class TestPipelineStartup(unittest.TestCase):
             pipeline.setup()
             self.assertDictEqual(pipeline.sample_dict, expected_output)
 
-    def test_correctdir_with_input_type_as_list(self) -> None:
+    def test_correctdir_with_input_type_as_tuple(self) -> None:
         """Testing the pipeline startup accepts both types"""
 
         expected_output = {
@@ -573,7 +573,7 @@ class TestPipelineStartup(unittest.TestCase):
         pipeline = Pipeline(
             **default_args,
             argv=["-i", "fake_dir_wsamples"],
-            input_type=["fastq", "fasta"],
+            input_type=("fastq", "fasta"),
         )
         pipeline.setup()
         pipeline.get_metadata_from_csv_file()
@@ -606,7 +606,7 @@ class TestPipelineStartup(unittest.TestCase):
         self.assertTrue(pipeline.input_dir_is_juno_assembly_output)
 
         pipeline_input_type_list = Pipeline(
-            **default_args, argv=["-i", str(input_dir)], input_type=["fastq", "fasta"]
+            **default_args, argv=["-i", str(input_dir)], input_type=("fastq", "fasta")
         )
         pipeline_input_type_list.setup()
         self.assertTrue(pipeline_input_type_list.input_dir_is_juno_assembly_output)
@@ -629,7 +629,7 @@ class TestPipelineStartup(unittest.TestCase):
         make_non_empty_file(input_dir.joinpath("reference", "reference.fasta"))
 
         pipeline = Pipeline(
-            **default_args, argv=["-i", str(input_dir)], input_type=["bam", "vcf"]
+            **default_args, argv=["-i", str(input_dir)], input_type=("bam", "vcf")
         )
         pipeline.setup()
         self.assertTrue(pipeline.input_dir_is_juno_mapping_output)
@@ -649,7 +649,7 @@ class TestPipelineStartup(unittest.TestCase):
         )
 
         pipeline = Pipeline(
-            **default_args, argv=["-i", str(input_dir)], input_type=["fasta"]
+            **default_args, argv=["-i", str(input_dir)], input_type=("fasta")
         )
         pipeline.setup()
         self.assertTrue(pipeline.input_dir_is_juno_variant_typing_output)

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -649,7 +649,7 @@ class TestPipelineStartup(unittest.TestCase):
         )
 
         pipeline = Pipeline(
-            **default_args, argv=["-i", str(input_dir)], input_type=("fasta")
+            **default_args, argv=["-i", str(input_dir)], input_type=("fasta",)
         )
         pipeline.setup()
         self.assertTrue(pipeline.input_dir_is_juno_variant_typing_output)


### PR DESCRIPTION
This PR adds:
- the possibility to enlist consensus fasta genomes from juno-variant-typing
- the possibility to enlist cgmlst allele calls in TSV format from juno-cgmlst. NB: juno-cgmlst needs an update to make this work, so currently this raises a NotImplementedError [^1]
- the possibility to specify input type by a tuple of input file formats, rather than a concatenated string of the input file formats (now `("fastq", "fasta")` instead of `"fastq_and_fasta"`). This makes future parsing easier.
- Generalized enlisting of files, instead of using fixed extensions. Due to the Illumina naming scheme which contains paired end information, the fastq enlisting is still the same


[^1]: juno-cgmlst now outputs a table with all allele calls for that run in a single TSV file. This needs to be split up in separate TSV files per sample per scheme, to be compatible with the Juno philosophy