### PR TITLE
Fix juno mapping enlisting

### DIFF
--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -518,63 +518,11 @@ class Pipeline:
         elif len(errors) > 1:
             raise KeyError(errors)
 
-    # def __enlist_fasta_samples(self, dir: Path) -> None:
-    #     """Function to enlist the fasta files found in the input directory.
-    #     Adds or updates self.sample_dict with the form:
-
-    #     {sample: {assembly: fasta_file}}
-    #     """
-    #     pattern = re.compile("(.*?).fasta")
-    #     for file_ in dir.iterdir():
-    #         if validate_file_has_min_lines(file_, self.min_num_lines):
-    #             if match := pattern.fullmatch(file_.name):
-    #                 sample_name = match.group(1)
-    #                 if sample_name in self.excluded_samples:
-    #                     continue
-    #                 sample = self.sample_dict.setdefault(sample_name, {})
-    #                 sample["assembly"] = str(file_.resolve())
-
-    # def __enlist_vcf_samples(self, dir: Path) -> None:
-    #     """Function to enlist VCF files found in the input directory.
-    #     Also looks for a reference but does not fail if it's not found.
-    #     Adds or updates self.sample_dict with the form:
-
-    #     {sample: {vcf: vcf_file}}
-    #     """
-    #     ref_path = dir.parent.joinpath("reference", "reference.fasta")
-    #     pattern = re.compile("(.*?).vcf")
-    #     for file_ in dir.iterdir():
-    #         if validate_file_has_min_lines(file_, self.min_num_lines):
-    #             if match := pattern.fullmatch(file_.name):
-    #                 sample_name = match.group(1)
-    #                 if sample_name in self.excluded_samples:
-    #                     continue
-    #                 sample = self.sample_dict.setdefault(sample_name, {})
-    #                 sample["vcf"] = str(file_.resolve())
-    #                 if ref_path.exists():
-    #                     sample["reference"] = str(ref_path.resolve())
-
     def __enlist_reference(self, dir: Path) -> None:
         ref_path = dir.joinpath("reference", "reference.fasta")
         for sample in self.sample_dict:
             if "reference" not in self.sample_dict[sample]:
                 self.sample_dict[sample]["reference"] = str(ref_path.resolve())
-
-    # def __enlist_bam_samples(self, dir: Path) -> None:
-    #     """Function to enlist BAM files found in the input directory.
-    #     Adds or updates self.sample_dict with the form:
-
-    #     {sample: {bam: bam_file}}
-    #     """
-    #     pattern = re.compile("(.*?).bam")
-    #     for file_ in dir.iterdir():
-    #         if validate_file_has_min_lines(file_, self.min_num_lines):
-    #             if match := pattern.fullmatch(file_.name):
-    #                 sample_name = match.group(1)
-    #                 if sample_name in self.excluded_samples:
-    #                     continue
-    #                 sample = self.sample_dict.setdefault(sample_name, {})
-    #                 sample["bam"] = str(file_.resolve())
 
     def __enlist_samples_custom_extension(
         self, dir: Path, extension: str, key: str

--- a/juno_library/juno_library.py
+++ b/juno_library/juno_library.py
@@ -440,6 +440,7 @@ class Pipeline:
             self.__enlist_samples_custom_extension(
                 self.input_dir.joinpath("variants"), extension=".vcf", key="vcf"
             )
+            self.__enlist_reference(self.input_dir)
         elif self.input_dir_is_juno_variant_typing_output:
             consensus_paths = list(self.input_dir.glob("*/consensus"))
             assert len(consensus_paths) == 1, error_formatter(

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -633,7 +633,9 @@ class TestPipelineStartup(unittest.TestCase):
         )
         pipeline.setup()
         self.assertTrue(pipeline.input_dir_is_juno_mapping_output)
-        self.assertTrue("reference" in pipeline.sample_dict['sample_A']) # regression test fixed by commit c6856d688e06329673f6d4e0197a39a2f4152766
+        self.assertTrue(
+            "reference" in pipeline.sample_dict["sample_A"]
+        )  # regression test fixed by commit c6856d688e06329673f6d4e0197a39a2f4152766
 
     def test_recognize_juno_variant_typing_output(self) -> None:
         """

--- a/tests/library_tests.py
+++ b/tests/library_tests.py
@@ -633,6 +633,7 @@ class TestPipelineStartup(unittest.TestCase):
         )
         pipeline.setup()
         self.assertTrue(pipeline.input_dir_is_juno_mapping_output)
+        self.assertTrue("reference" in pipeline.sample_dict['sample_A']) # regression test fixed by commit c6856d688e06329673f6d4e0197a39a2f4152766
 
     def test_recognize_juno_variant_typing_output(self) -> None:
         """


### PR DESCRIPTION
Forgot to call `__enlist_reference` if output is recognised as juno_mapping output. Added a regression unit test for this